### PR TITLE
Shader smart play rework

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -22,10 +22,6 @@
       <label>Pause the video when existing a maximized or full-screen windows.</label>
       <default>false</default>
     </entry>
-    <entry name="checkedBusyPlay" type="bool">
-      <label>Pause the video when the desktop is busy.</label>
-      <default>true</default>
-    </entry>
     <entry name="checkGl3Ver" type="bool">
       <label>Change gl3 version for shader compatibility.</label>
       <default>true</default>

--- a/contents/ui/config.qml
+++ b/contents/ui/config.qml
@@ -11,7 +11,6 @@ Item {
   property alias cfg_selectedShader:   selectedShaderField.text
   property alias cfg_checkGl3Ver:      checkGl3Ver.checked
   property alias cfg_checkedSmartPlay: checkedSmartPlay.checked
-  property alias cfg_checkedBusyPlay:  checkedBusyPlay.checked
   property alias cfg_iChannel0_flag:   iChannel0_flag.checked
   property alias cfg_iChannel1_flag:   iChannel1_flag.checked
   property alias cfg_iChannel2_flag:   iChannel2_flag.checked
@@ -566,34 +565,10 @@ Item {
                   color: "white"
                   padding:5
                 }
-                RadioButton {
+                CheckBox {
                   id: checkedSmartPlay
-                  // checkable: false
-                  // opacity: 0.25
-                  checked: !checkedBusyPlay.checked
-                  text: i18n("Pause the shader when maximized or full-screen windows.")
-                  onCheckedChanged: {
-                    checkedBusyPlay.checked = !checkedSmartPlay.checked
-                  }
-                }
-              }
-
-              RowLayout{
-                Layout.fillWidth: true
-                Text {
-                  width:100
-                  color: "white"
-                  padding:5
-                }
-                RadioButton {
-                  id: checkedBusyPlay
-                  // checkable: false
-                  // opacity: 0.25
-                  checked: !checkedSmartPlay.checked
-                  text: i18n("Pause the shader when the desktop is busy.")
-                  onCheckedChanged: {
-                    checkedSmartPlay.checked = !checkedBusyPlay.checked
-                  }
+                  checked: false
+                  text: i18n("Pause the shader when covered by maximized or full-screen windows.")
                 }
               }
           }


### PR DESCRIPTION
Makes shader smart play work with multiple monitors, by only stopping a shader if it's actually covered by a window (previously shader would be stopped if there was any fullscreen window, even on another monitor). Changes smart play control to one checkbox.

Also removes bunch of stuff that seemed unnecessary to me. If I missed something and I removed something useful, please let me know.

I believe this fixes #11 and #17.