### PR TITLE
Fixed small error in iChannel assignments

### DIFF
--- a/ShaderProcessor.py
+++ b/ShaderProcessor.py
@@ -34,9 +34,9 @@ layout(std140, binding = 0) uniform buf {
 } ubuf;
 
 layout(binding = 1) uniform sampler2D iChannel0;
-layout(binding = 1) uniform sampler2D iChannel1;
-layout(binding = 1) uniform sampler2D iChannel2;
-layout(binding = 1) uniform sampler2D iChannel3;
+layout(binding = 2) uniform sampler2D iChannel1;
+layout(binding = 3) uniform sampler2D iChannel2;
+layout(binding = 4) uniform sampler2D iChannel3;
 
 vec2 fragCoord = vec2(qt_TexCoord0.x, 1.0 - qt_TexCoord0.y) * ubuf.iResolution.xy;
 '''


### PR DESCRIPTION
Using the ShaderProcessor.py script on a few ShaderToy shaders resulted in improper binding of the iChannel0-3 uniforms. Behavior was inconsistent, but mostly resulted in iChannel3 being the only accessible sampler2D. By continuing to increment the value passed to `layout(binding=#)` I am able to access all 4 sampler2D uniforms.