### PR TITLE
Add `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+    # IDE & Editor-specific directories
+    .zed/
+
+    # Virtual environment directories
+    .venv/
+
+    # `.frag` conversion directory
+    package/contents/ui/Shaders/ConvertMe/


### PR DESCRIPTION
Instantiated `.gitignore` with sections for editor-specific directories, python virtual environment directories, and the `ConvertMe` directory used to compile `.frag` files to `.qsb`.

The directories for virtual environments are handy if the user uses `conda` or `venv` to manage python packages but needs to symlink to a directory in the root of the repo to ensure that packages are readable/executable with their IDE/editor of choice.