### PR TITLE
Made iFrameRate functional and configurable in settings GUI

### DIFF
--- a/package/contents/ui/config.qml
+++ b/package/contents/ui/config.qml
@@ -23,6 +23,7 @@ Kirigami.FormLayout {
     property bool cfg_iChannel2_flag: wallpaper.configuration.iChannel2_flag
     property bool cfg_iChannel3_flag: wallpaper.configuration.iChannel3_flag
     property string cfg_selectedShaderPath: wallpaper.configuration.selectedShaderPath
+    property int cfg_iFrameRate: wallpaper.configuration.iFrameRate
     property double cfg_shaderSpeed: wallpaper.configuration.shaderSpeed
     property double cfg_mouseSpeedBias: wallpaper.configuration.mouseSpeedBias
     property bool cfg_mouseAllowed: wallpaper.configuration.mouseAllowed
@@ -138,6 +139,58 @@ Kirigami.FormLayout {
             onCheckedChanged: {
                 wallpaper.configuration.running = checked;
                 cfg_running = checked;
+            }
+        }
+    }
+
+    RowLayout {
+        Kirigami.FormData.label: i18nd("online.knowmad.shaderwallpaper", "Frames Per Second:")
+        ColumnLayout {
+            Slider {
+                id: iFrameRateSlider
+                Layout.preferredWidth: Kirigami.Units.gridUnit * 16
+                from: 0
+                to: 120
+                stepSize: 1
+                value: cfg_iFrameRate >= 0 ? cfg_iFrameRate : 60
+                onValueChanged: {
+                    iFrameRateField.text = String(value);
+                    wallpaper.configuration.iFrameRate = iFrameRateField.text;
+                    cfg_iFrameRate = iFrameRateField.text;
+                }
+            }
+        }
+        ColumnLayout {
+            TextField {
+                id: iFrameRateField
+                text: cfg_iFrameRate >= 0  ? String(cfg_iFrameRate) : "60"
+                inputMethodHints: Qt.NumberInput
+                Layout.preferredWidth: Kirigami.Units.gridUnit * 3
+                onEditingFinished: {
+                    let inputValue = parseInt(text);
+                    // Value should never go below 0, but can go above our max
+                    if (isNaN(inputValue) || inputValue < iFrameRateSlider.from) {
+                        inputValue = iFrameRateSlider.from;
+                    }
+                    text = inputValue;
+                    iFrameRateSlider.value = inputValue;
+                    wallpaper.configuration.iFrameRate = inputValue;
+                    cfg_iFrameRate = inputValue;
+                }
+                Keys.onPressed: {
+                    if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                        iFrameRateField.focus = false; // Unfocus the TextField
+                        event.accepted = true; // Prevent further propagation of the key event
+                    }
+                }
+                background: Rectangle {
+                    color: iFrameRateField.activeFocus ? palette.base : "transparent"
+                    border.color: iFrameRateField.activeFocus ? palette.highlight : "transparent"
+                    border.width: 1
+                    radius: 4
+                    anchors.fill: iFrameRateField
+                    anchors.margins: -2
+                }
             }
         }
     }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -150,9 +150,9 @@ WallpaperItem {
 
     Timer {
         id: timer1
-        running: wallpaper.configuration.running ? windowModel.runShader : false
+        running: wallpaper.configuration.running && wallpaper.configuration.iFrameRate != 0 && windowModel.runShader
         triggeredOnStart: true
-        interval: 16
+        interval: 1.0 / (wallpaper.configuration.iFrameRate && wallpaper.configuration.iFrameRate > 0 ? wallpaper.configuration.iFrameRate : 60) * 1000.0
         repeat: true
         onTriggered: {
             var now = new Date();
@@ -164,8 +164,8 @@ WallpaperItem {
             var second = now.getSeconds();
             var startOfDay = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
             var secondsSinceMidnight = (now - startOfDay) / 1000;
-
-            shader.iTime += 0.016 * (wallpaper.configuration.shaderSpeed ? wallpaper.configuration.shaderSpeed : 1.0);
+            var step = 1.0 / (wallpaper.configuration.iFrameRate ? wallpaper.configuration.iFrameRate : 60.0);
+            shader.iTime += step * (wallpaper.configuration.shaderSpeed ? wallpaper.configuration.shaderSpeed : 1.0);
             shader.iFrame += 1;
             shader.iDate = Qt.vector4d(0., 0., 0., secondsSinceMidnight);
         }


### PR DESCRIPTION
Addressing Issues GH-68 and GH-85

Exposed iFrameRate to the wallpaper settings and hooked it up to the timer in main.qml.
Followed the formatting and layout of shaderSpeed for the ui in config.qml.
Frame rate will default to 60, which is a similar interval to what we had before.

<img width="589" height="492" alt="image" src="https://github.com/user-attachments/assets/48931c3f-d167-454d-ae9c-0a59d3a9d68b" />