### PR TITLE
2nd Refactor of `ShaderProcessor.py` for Robustness and Efficiency

### DIFF
--- a/ShaderProcessor.py
+++ b/ShaderProcessor.py
@@ -1,18 +1,24 @@
-import os
 import re
+from pathlib import Path
 
-# Specify the directory where your .frag files are located
-directory_path = 'package/contents/ui/Shaders/ConvertMe'
+# Configuration
+DIRECTORY_PATH = Path("package/contents/ui/Shaders/ConvertMe")
 
-# List of variables to update
-variables_to_update = [
-    'iTime', 'iTimeDelta', 'iFrameRate', 'iSampleRate',
-    'iFrame', 'iDate', 'iMouse', 'iResolution',
-    r'iChannelTime', r'iChannelResolution'
+# Variables to map to the ubuf struct
+VARS_TO_MAP = [
+    "iTime",
+    "iTimeDelta",
+    "iFrameRate",
+    "iSampleRate",
+    "iFrame",
+    "iDate",
+    "iMouse",
+    "iResolution",
+    "iChannelTime",
+    "iChannelResolution",
 ]
 
-# Header to be prepended to the shader file
-header = '''#version 450
+HEADER = """#version 450
 
 layout(location = 0) in vec2 qt_TexCoord0;
 layout(location = 0) out vec4 fragColor;
@@ -38,42 +44,51 @@ layout(binding = 3) uniform sampler2D iChannel2;
 layout(binding = 4) uniform sampler2D iChannel3;
 
 vec2 fragCoord = vec2(qt_TexCoord0.x, 1.0 - qt_TexCoord0.y) * ubuf.iResolution.xy;
-'''
+"""
 
-# Footer to be appended, containing the main entry point
-footer = '''
+FOOTER = """
 void main() {
     vec4 color = vec4(0.0);
     mainImage(color, fragCoord);
     fragColor = color;
 }
-'''
+"""
 
-for root, dirs, files in os.walk(directory_path):
-    for file in files:
-        if file.endswith('.frag'):
-            file_path = os.path.join(root, file)
-            with open(file_path, 'r+', encoding='utf-8') as f:
-                content = f.read()
+# Compile a single regex for all variables
+# Uses a negative lookbehind to ensure we don't double-prefix ubuf.ubuf.iTime
+VAR_PATTERN = re.compile(rf"(?<!\.)\b({'|'.join(VARS_TO_MAP)})\b")
 
-                # 1. Remove any existing #version directive to avoid conflicts
-                content = re.sub(r'^\s*#version\s+.*?\n', '', content, flags=re.MULTILINE)
 
-                # 2. Remove any pre-existing main() function
-                content = re.sub(r'void\s+main\s*\([^)]*\)\s*\{[\s\S]*?\}', '', content)
+def process_shader(file_path: Path):
+    content = file_path.read_text(encoding="utf-8")
 
-                # 3. Prepend 'ubuf.' to all shadertoy uniforms
-                for var in variables_to_update:
-                    pattern = r'(?<!\.)\b' + var + r'\b'
-                    replacement = 'ubuf.' + var
-                    content = re.sub(pattern, replacement, content)
+    # Check if already processed (Idempotency)
+    if "layout(std140, binding = 0) uniform buf" in content:
+        return False
 
-                # 4. Assemble the final, complete shader
-                final_content = header + '\n' + content.strip() + '\n' + footer
+    # Strip existing #version
+    content = re.sub(r"^\s*#version\s+.*?\n", "", content, flags=re.MULTILINE)
 
-                # Write the updated content back to the file
-                f.seek(0)
-                f.write(final_content)
-                f.truncate()
+    # Strip existing void main().
+    # Instead of parsing braces, we strip everything from 'void main' to the end
+    # of the file, assuming it was added by a previous run or is boilerplate.
+    content = re.sub(r"void\s+main\s*\([\s\S]*$", "", content).strip()
 
-            print(f"Successfully processed {file}")
+    # Map variables to ubuf. in a single pass
+    content = VAR_PATTERN.sub(lambda m: f"ubuf.{m.group(1)}", content)
+
+    # Reassemble
+    final_content = f"{HEADER}\n{content}\n{FOOTER}"
+    file_path.write_text(final_content, encoding="utf-8")
+    return True
+
+
+if __name__ == "__main__":
+    if not DIRECTORY_PATH.exists():
+        print(f"Error: {DIRECTORY_PATH} does not exist.")
+    else:
+        for shader in DIRECTORY_PATH.rglob("*.frag"):
+            if process_shader(shader):
+                print(f"Successfully processed: {shader.name}")
+            else:
+                print(f"Skipped (already processed): {shader.name}")


### PR DESCRIPTION
# 2nd Refactor of `ShaderProcessor.py` for Robustness and Efficiency

This PR completely refactors the `ShaderProcessor.py` script. Upon review, it became clear that my previous implementation was a somewhat "ham-fisted" attempt at refactoring that relied on brittle regex and inefficient multi-pass processing. This version adopts a more surgical approach.

## Key Improvements:

- **Single-Pass Variable Mapping**: Replaced the iterative `re.sub` loop (which ran 10 times per file) with a single-pass regex compiled with a negative lookbehind. This is not only more efficient but safer against double-prefixing.
- **Improved Entry Point Stripping**: The previous logic for removing `void main()` was prone to failure if the function contained nested braces. The new logic assumes the fragment is being "wrapped" and cleanly strips the existing entry point to the end of the file before appending the custom footer.
- **Strict Idempotency**: Added an explicit check for the `ubuf` uniform block. If a file has already been processed, the script will skip it rather than attempting to prepend the header again, preventing file corruption on repeated runs.
- **Modernized File I/O**: Migrated from `os.path` and `os.walk` to `pathlib`, making the script more readable and cross-platform friendly.
- **Resilient Regex**: Updated patterns to handle varying whitespace and formatting more gracefully.

## Testing:
- Verified with my custom fragment (e.g., `Supah_Relax_Cyan.frag`) using `#7da39c` (a shade of green-cyan) as the base color that was converted to an appropriate `vec3`.
- Confirmed that running the script multiple times does not result in duplicate headers.
- Verified successful compilation via `ShaderCompiler.py` once `qsb` was correctly mapped in the environment `PATH`.