### PR TITLE
Add fallback for unsupported buffer FBO formats

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SHADER_WALLPAPER_SOURCES
 
 set(SHADER_WALLPAPER_HEADERS
     # Core
+    core/framebufferutils.h
     core/shaderengine.h
     core/shaderbuffer.h
     core/shadercompiler.h

--- a/src/core/framebufferutils.h
+++ b/src/core/framebufferutils.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 KDE contributors
+
+#ifndef FRAMEBUFFERUTILS_H
+#define FRAMEBUFFERUTILS_H
+
+#include <QOpenGLFramebufferObject>
+#include <QSize>
+
+#include <array>
+#include <memory>
+
+namespace FramebufferUtils
+{
+
+struct BufferPair
+{
+    std::unique_ptr<QOpenGLFramebufferObject> front;
+    std::unique_ptr<QOpenGLFramebufferObject> back;
+    GLenum internalTextureFormat = 0;
+
+    explicit operator bool() const
+    {
+        return front && front->isValid() && back && back->isValid();
+    }
+};
+
+inline const char *textureFormatName(GLenum format)
+{
+    switch (format) {
+    case GL_RGBA32F:
+        return "GL_RGBA32F";
+    case GL_RGBA16F:
+        return "GL_RGBA16F";
+    case GL_RGBA8:
+        return "GL_RGBA8";
+    default:
+        return "unknown";
+    }
+}
+
+inline BufferPair createBufferPair(const QSize &size)
+{
+    // Preserve full precision where supported. Some OpenGL contexts created by
+    // Plasma cannot render to RGBA32F, so progressively use broader formats.
+    constexpr std::array<GLenum, 3> formats = {
+        GL_RGBA32F,
+        GL_RGBA16F,
+        GL_RGBA8,
+    };
+
+    QOpenGLFramebufferObjectFormat format;
+    format.setAttachment(QOpenGLFramebufferObject::NoAttachment);
+    format.setMipmap(false);
+
+    for (const GLenum internalFormat : formats) {
+        format.setInternalTextureFormat(internalFormat);
+
+        BufferPair pair;
+        pair.front = std::make_unique<QOpenGLFramebufferObject>(size, format);
+        pair.back = std::make_unique<QOpenGLFramebufferObject>(size, format);
+        pair.internalTextureFormat = internalFormat;
+
+        // Ping-pong buffers must use the same renderable format.
+        if (pair) {
+            return pair;
+        }
+    }
+
+    return {};
+}
+
+}
+
+#endif // FRAMEBUFFERUTILS_H

--- a/src/core/shaderbuffer.cpp
+++ b/src/core/shaderbuffer.cpp
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: 2024 @y4my4my4m <y4my4my4m@protonmail.com>
 
 #include "shaderbuffer.h"
+#include "framebufferutils.h"
 
+#include <QDebug>
 #include <QOpenGLContext>
 #include <QOpenGLFunctions>
 
@@ -140,14 +142,17 @@ void ShaderBuffer::resize(const QSize &size)
 
 void ShaderBuffer::createFBOs()
 {
-    QOpenGLFramebufferObjectFormat format;
-    format.setAttachment(QOpenGLFramebufferObject::NoAttachment);
-    format.setInternalTextureFormat(GL_RGBA32F);
-    format.setMipmap(false);
+    auto pair = FramebufferUtils::createBufferPair(m_size);
+    if (!pair) {
+        m_fbo[0].reset();
+        m_fbo[1].reset();
+        qWarning() << m_name
+                   << "FBO creation failed for GL_RGBA32F, GL_RGBA16F, and GL_RGBA8";
+        return;
+    }
 
-    m_fbo[0] = std::make_unique<QOpenGLFramebufferObject>(m_size, format);
-    m_fbo[1] = std::make_unique<QOpenGLFramebufferObject>(m_size, format);
-
+    m_fbo[0] = std::move(pair.front);
+    m_fbo[1] = std::move(pair.back);
     auto *f = QOpenGLContext::currentContext()->functions();
 
     for (int i = 0; i < 2; i++) {
@@ -169,6 +174,9 @@ void ShaderBuffer::createFBOs()
         f->glClear(GL_COLOR_BUFFER_BIT);
         m_fbo[i]->release();
     }
+
+    qInfo() << "Created" << m_name << "FBO pair, size:" << m_size
+            << "format:" << FramebufferUtils::textureFormatName(pair.internalTextureFormat);
 }
 
 bool ShaderBuffer::compile()
@@ -220,7 +228,7 @@ void ShaderBuffer::render(const std::function<void(QOpenGLShaderProgram*)> &unif
                           const std::function<GLuint(int)> &getTexture)
 {
     if (!m_enabled || !m_compiled || !m_program) return;
-    if (!m_fbo[m_currentBuffer]) return;
+    if (!m_fbo[m_currentBuffer] || !m_fbo[m_currentBuffer]->isValid()) return;
 
     auto *f = QOpenGLContext::currentContext()->functions();
 
@@ -325,7 +333,7 @@ void ShaderBuffer::swapBuffers()
 
 GLuint ShaderBuffer::currentTexture() const
 {
-    if (m_fbo[m_currentBuffer]) {
+    if (m_fbo[m_currentBuffer] && m_fbo[m_currentBuffer]->isValid()) {
         return m_fbo[m_currentBuffer]->texture();
     }
     return 0;
@@ -334,7 +342,7 @@ GLuint ShaderBuffer::currentTexture() const
 GLuint ShaderBuffer::previousTexture() const
 {
     const int prevBuffer = 1 - m_currentBuffer;
-    if (m_fbo[prevBuffer]) {
+    if (m_fbo[prevBuffer] && m_fbo[prevBuffer]->isValid()) {
         return m_fbo[prevBuffer]->texture();
     }
     return 0;

--- a/src/core/shaderengine.cpp
+++ b/src/core/shaderengine.cpp
@@ -3,6 +3,7 @@
 
 #include "shaderengine.h"
 #include "shadercompiler.h"
+#include "framebufferutils.h"
 #include "data/shaderlibrary.h"
 
 #include <QFile>
@@ -1516,46 +1517,42 @@ void ShaderEngineRenderer::ensureBufferFBOs(int bufferIndex)
         f->glBindTexture(GL_TEXTURE_2D, 0);
     };
 
-    QOpenGLFramebufferObjectFormat bufferFormat;
-    bufferFormat.setAttachment(QOpenGLFramebufferObject::NoAttachment);
-    bufferFormat.setInternalTextureFormat(GL_RGBA32F);
-    
-    // Ensure both ping-pong FBOs exist for this buffer
-    if (!m_bufferFBOs[bufferIndex] || m_bufferFBOs[bufferIndex]->size() != bufSize) {
-        m_bufferFBOs[bufferIndex] = std::make_unique<QOpenGLFramebufferObject>(bufSize, bufferFormat);
-        
-        if (!m_bufferFBOs[bufferIndex]->isValid()) {
-            qWarning() << "Buffer" << bufferIndex << "FBO creation failed!";
-        } else {
-            configureBufferTexture(m_bufferFBOs[bufferIndex]->texture());
-            qDebug() << "Created Buffer" << bufferIndex << "FBO, size:" << bufSize
-                     << "(native" << m_fboSize << ", simMaxH" << m_bufferSimulationMaxHeight << ")";
-        }
-        
-        // Clear the new FBO
-        auto *f = QOpenGLContext::currentContext()->functions();
-        m_bufferFBOs[bufferIndex]->bind();
+    const bool needsFBOs =
+        !m_bufferFBOs[bufferIndex]
+        || !m_bufferFBOsBack[bufferIndex]
+        || m_bufferFBOs[bufferIndex]->size() != bufSize
+        || m_bufferFBOsBack[bufferIndex]->size() != bufSize;
+    if (!needsFBOs) {
+        return;
+    }
+
+    auto pair = FramebufferUtils::createBufferPair(bufSize);
+    if (!pair) {
+        m_bufferFBOs[bufferIndex].reset();
+        m_bufferFBOsBack[bufferIndex].reset();
+        qWarning() << "Buffer" << bufferIndex
+                   << "FBO creation failed for GL_RGBA32F, GL_RGBA16F, and GL_RGBA8";
+        return;
+    }
+
+    m_bufferFBOs[bufferIndex] = std::move(pair.front);
+    m_bufferFBOsBack[bufferIndex] = std::move(pair.back);
+
+    configureBufferTexture(m_bufferFBOs[bufferIndex]->texture());
+    configureBufferTexture(m_bufferFBOsBack[bufferIndex]->texture());
+
+    auto *f = QOpenGLContext::currentContext()->functions();
+    for (QOpenGLFramebufferObject *fbo :
+         {m_bufferFBOs[bufferIndex].get(), m_bufferFBOsBack[bufferIndex].get()}) {
+        fbo->bind();
         f->glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
         f->glClear(GL_COLOR_BUFFER_BIT);
-        m_bufferFBOs[bufferIndex]->release();
+        fbo->release();
     }
-    
-    if (!m_bufferFBOsBack[bufferIndex] || m_bufferFBOsBack[bufferIndex]->size() != bufSize) {
-        m_bufferFBOsBack[bufferIndex] = std::make_unique<QOpenGLFramebufferObject>(bufSize, bufferFormat);
-        
-        if (!m_bufferFBOsBack[bufferIndex]->isValid()) {
-            qWarning() << "Buffer" << bufferIndex << "back FBO creation failed!";
-        } else {
-            configureBufferTexture(m_bufferFBOsBack[bufferIndex]->texture());
-        }
-        
-        // Clear the new FBO
-        auto *f = QOpenGLContext::currentContext()->functions();
-        m_bufferFBOsBack[bufferIndex]->bind();
-        f->glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-        f->glClear(GL_COLOR_BUFFER_BIT);
-        m_bufferFBOsBack[bufferIndex]->release();
-    }
+
+    qInfo() << "Created Buffer" << bufferIndex << "FBO pair, size:" << bufSize
+            << "format:" << FramebufferUtils::textureFormatName(pair.internalTextureFormat)
+            << "(native" << m_fboSize << ", simMaxH" << m_bufferSimulationMaxHeight << ")";
 }
 
 QSize ShaderEngineRenderer::computeBufferSimSize() const
@@ -2091,4 +2088,3 @@ void ShaderEngineRenderer::synchronize(QQuickFramebufferObject *item)
     m_virtualDesktopCount = engine->virtualDesktopCount();
     m_virtualDesktopAnim  = engine->virtualDesktopAnim();
 }
-


### PR DESCRIPTION
I have two GPUs and when using the dedicated one, some shaders will spam
```
Buffer 0 FBO is invalid!
Buffer 0 FBO is null or invalid for channel 1
```
in the console

this seemed to be caused by the fact that not all openGL contexts are created equal.

with the help of AI, we created a helper that will create buffers with the highest-supported-precision level

## Summary

Fix buffer-backed `iChannel` inputs failing on OpenGL contexts that do not support `GL_RGBA32F` render targets.

## Changes

- Try buffer formats in order:
  1. `GL_RGBA32F`
  2. `GL_RGBA16F`
  3. `GL_RGBA8`
- Require both ping-pong FBOs to be valid.
- Share fallback logic between `ShaderEngineRenderer` and `ShaderBuffer`.
- Log selected format.
- Avoid binding invalid FBOs.

## Before

```text
Buffer 0 FBO creation failed!
Buffer 0 FBO is null or invalid for channel 1
```

## After

Buffer FBOs are created using the highest-precision supported format. On affected hardware, creation falls back to `GL_RGBA16F` (or lower but I didn't have possibility to test)

## Testing

- Project builds successfully.
- `ctest --test-dir build --output-on-failure`: 1/1 passed.
- Verified affected setup creates buffer FBOs with `GL_RGBA16F`.