### PR TITLE
Fix Pause Not Working

### DIFF
--- a/package/contents/ui/ShaderSystem.qml
+++ b/package/contents/ui/ShaderSystem.qml
@@ -37,7 +37,8 @@ Item {
     WindowModel {
         id: windowModel
         config: shaderSystem.wallpaperConfig
-        screenGeometry: shaderSystem.parent?.parent?.screenGeometry ?? Qt.rect(0, 0, 1920, 1080)
+        screenGeometry: Qt.rect(Screen.virtualX, Screen.virtualY,
+                                Screen.width, Screen.height)
     }
 
     // Cursor tracker for global mouse position. We explicitly bind
@@ -118,8 +119,8 @@ Item {
     QtObject {
         id: screenInfo
         property var screens: Qt.application.screens
-        property rect myGeom: shaderSystem.parent?.parent?.screenGeometry
-                              ?? Qt.rect(0, 0, 1920, 1080)
+        property rect myGeom: Qt.rect(Screen.virtualX, Screen.virtualY,
+                                      Screen.width, Screen.height)
         property real virtualX0: {
             var x = Number.POSITIVE_INFINITY;
             for (var i = 0; i < screens.length; i++)


### PR DESCRIPTION
I ran into #122 and this ended up being the solution for me. I'm not able to test on X11 but does fix pause for me on Wayland as expected.

```Operating System: Arch Linux 
KDE Plasma Version: 6.7.3
KDE Frameworks Version: 6.28.0
Qt Version: 6.11.1
Kernel Version: 7.1.4-zen1-1-zen (64-bit)
Graphics Platform: Wayland (1600x2560 (rotated) + 3840x2160)
Processors: 24 × AMD Ryzen 9 5900X 12-Core Processor
Memory: 32 GiB of RAM (31.2 GiB usable)
Graphics Processor: AMD Radeon RX 9070 XT
```

Maybe the hierarchy used to be different?

From the commit:

> Both screen-geometry lookups in ShaderSystem read
> 
>     shaderSystem.parent?.parent?.screenGeometry ?? Qt.rect(0, 0, 1920, 1080)
> 
> ...but WallpaperItem (.parent.parent) has no screenGeometry property, so
> they always resolved to undefined and silently used the fallback. Since
> this feeds through to TaskModel.filterScreen, windows got matched
> incorrectly against the 1920x1080 fallback.
